### PR TITLE
Pythonsdk-80: Fixed parsing of string response payloads

### DIFF
--- a/ds3/ds3.py
+++ b/ds3/ds3.py
@@ -8937,7 +8937,7 @@ class GetJobToReplicateSpectraS3Response(AbstractResponse):
     def process_response(self, response):
         self.__check_status_codes__([200])
         if self.response.status == 200:
-            self.result = parseModel(xmldom.fromstring(response.read()), String())
+            self.result = response.read()
 
 
 class GetJobsSpectraS3Response(AbstractResponse):
@@ -9567,7 +9567,7 @@ class GetBlobPersistenceSpectraS3Response(AbstractResponse):
     def process_response(self, response):
         self.__check_status_codes__([200])
         if self.response.status == 200:
-            self.result = parseModel(xmldom.fromstring(response.read()), String())
+            self.result = response.read()
 
 
 class GetObjectDetailsSpectraS3Response(AbstractResponse):

--- a/tests/clientTests.py
+++ b/tests/clientTests.py
@@ -13,9 +13,6 @@ import sys
 import tempfile
 import unittest
 
-from http.client import HTTPResponse
-from unittest.mock import Mock
-
 from ds3.ds3 import *
 
 bucketName = "python_test_bucket"
@@ -1360,29 +1357,37 @@ class Ds3NetworkTestCase(Ds3TestCase):
 
         self.assertEqual(result, expected)
 
+
+class MockedHttpResponse:
+    def __init__(self, status, content="", headers=[]):
+        self.status = status
+        self.headers = headers
+        self.content = content
+
+    def getheaders(self):
+        return self.headers
+
+    def read(self):
+        return self.content
+
+
 class ResponseParsingTestCase(unittest.TestCase):
     def testGetJobToReplicate(self):
         content = "some content to test response parsing"
 
-        mocked_request = Mock(spec=GetJobToReplicateSpectraS3Request)
+        request = GetJobToReplicateSpectraS3Request("jobId")
 
-        mocked_response = Mock(spec=HTTPResponse)
-        mocked_response.status = 200
-        mocked_response.getheaders = Mock(return_value=[])
-        mocked_response.read = Mock(return_value=content)
+        mocked_response = MockedHttpResponse(200, content)
 
-        response = GetJobToReplicateSpectraS3Response(mocked_response, mocked_request)
+        response = GetJobToReplicateSpectraS3Response(mocked_response, request)
         self.assertEqual(response.result, content)
 
     def testGetBlobPersistence(self):
         content = "some content to test response parsing"
 
-        mocked_request = Mock(spec=GetBlobPersistenceSpectraS3Request)
+        mocked_request = GetBlobPersistenceSpectraS3Request("request payload")
 
-        mocked_response = Mock(spec=HTTPResponse)
-        mocked_response.status = 200
-        mocked_response.getheaders = Mock(return_value=[])
-        mocked_response.read = Mock(return_value=content)
+        mocked_response = MockedHttpResponse(200, content)
 
         response = GetBlobPersistenceSpectraS3Response(mocked_response, mocked_request)
         self.assertEqual(response.result, content)

--- a/tests/clientTests.py
+++ b/tests/clientTests.py
@@ -13,11 +13,14 @@ import sys
 import tempfile
 import unittest
 
+from http.client import HTTPResponse
+from unittest.mock import Mock
+
 from ds3.ds3 import *
 
 bucketName = "python_test_bucket"
 resources = ["beowulf.txt", "sherlock_holmes.txt", "tale_of_two_cities.txt", "ulysses.txt"]
-bigFile = "lesmis.txt";
+bigFile = "lesmis.txt"
 unicodeResources = [str(filename) for filename in resources]
 
 
@@ -1356,3 +1359,30 @@ class Ds3NetworkTestCase(Ds3TestCase):
         result = self.client.net_client.build_path("/test/path/" + obj_name)
 
         self.assertEqual(result, expected)
+
+class ResponseParsingTestCase(unittest.TestCase):
+    def testGetJobToReplicate(self):
+        content = "some content to test response parsing"
+
+        mocked_request = Mock(spec=GetJobToReplicateSpectraS3Request)
+
+        mocked_response = Mock(spec=HTTPResponse)
+        mocked_response.status = 200
+        mocked_response.getheaders = Mock(return_value=[])
+        mocked_response.read = Mock(return_value=content)
+
+        response = GetJobToReplicateSpectraS3Response(mocked_response, mocked_request)
+        self.assertEqual(response.result, content)
+
+    def testGetBlobPersistence(self):
+        content = "some content to test response parsing"
+
+        mocked_request = Mock(spec=GetBlobPersistenceSpectraS3Request)
+
+        mocked_response = Mock(spec=HTTPResponse)
+        mocked_response.status = 200
+        mocked_response.getheaders = Mock(return_value=[])
+        mocked_response.read = Mock(return_value=content)
+
+        response = GetBlobPersistenceSpectraS3Response(mocked_response, mocked_request)
+        self.assertEqual(response.result, content)


### PR DESCRIPTION
Fixed parsing of response payloads of type String which previously produced errors.

Added MockedHttpResponse for creating unit tests for response handlers that do not require a client.

All tests passing.