### PR TITLE
PYTHONSDK-87: networking bug fix so all requests with payloads send their payloads

### DIFF
--- a/ds3/ds3network.py
+++ b/ds3/ds3network.py
@@ -213,7 +213,7 @@ class NetworkClient(object):
 
         headers.update(amz_headers)
 
-        if request.http_verb == HttpVerb.PUT or request.http_verb == HttpVerb.POST:
+        if request.body is not None and request.body is not "":
             canonicalized_amz_header = self.canonicalized_amz_headers(amz_headers)
             headers['Content-Type'] = 'application/octet-stream'
             headers['Authorization'] = self.build_authorization(verb=request.http_verb,

--- a/tests/clientTests.py
+++ b/tests/clientTests.py
@@ -678,6 +678,18 @@ class ObjectTestCase(Ds3TestCase):
         
         self.assertEqual(len(response.result['ObjectList']), 4)
 
+    def testVerifyPhysicalPlacement(self):
+        populateTestData(self.client, bucketName, self.getDataPolicyId())
+
+        object_list = FileObjectList([FileObject(name="beowulf.txt")])
+
+        request = VerifyPhysicalPlacementForObjectsSpectraS3Request(bucket_name=bucketName, object_list=object_list)
+
+        try:
+            self.client.verify_physical_placement_for_objects_spectra_s3(request)
+        except RequestFailed as err:
+            self.assertEqual(err.http_error_code, 404)
+
 
 class ObjectMetadataTestCase(Ds3TestCase):
     def testHeadObject(self):
@@ -1391,3 +1403,11 @@ class ResponseParsingTestCase(unittest.TestCase):
 
         response = GetBlobPersistenceSpectraS3Response(mocked_response, mocked_request)
         self.assertEqual(response.result, content)
+
+    def testVerifyPhysicalPlacementRequestPayload(self):
+        obj1 = FileObject(name="obj1")
+        obj2 = FileObject(name="obj2")
+        l = FileObjectList([obj1, obj2])
+
+        request = VerifyPhysicalPlacementForObjectsSpectraS3Request(bucket_name="bucketName", object_list=l)
+        self.assertEqual(request.body.decode(), '<Objects><Object Name="obj1" /><Object Name="obj2" /></Objects>')


### PR DESCRIPTION
All tests pass.

Same as change to Python 2.7 SDK https://github.com/SpectraLogic/ds3_python_sdk/pull/120