### PR TITLE
SA-196: Added request payloads to clear blob and mark blob commands

### DIFF
--- a/ds3/ds3.py
+++ b/ds3/ds3.py
@@ -137,6 +137,22 @@ class PartList(object):
         return xml_part_list
 
 
+class IdsList(object):
+    def __init__(self, id_list):
+        for cur_id in id_list:
+            if not isinstance(cur_id, str):
+                raise TypeError("Ids should only contain strings")
+        self.id_list = id_list
+
+    def to_xml(self):
+        xml_id_list = xmldom.Element('Ids')
+        for cur_id in self.id_list:
+            xml_cur_id = xmldom.Element('Id')
+            xml_cur_id.text = cur_id
+            xml_id_list.append(xml_cur_id)
+        return xml_id_list
+
+
 # Type Descriptors
 
 
@@ -3461,8 +3477,15 @@ class ModifyS3DataReplicationRuleSpectraS3Request(AbstractRequest):
 
 class ClearSuspectBlobAzureTargetsSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(ClearSuspectBlobAzureTargetsSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'ClearSuspectBlobAzureTargetsSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_azure_target'
@@ -3471,8 +3494,15 @@ class ClearSuspectBlobAzureTargetsSpectraS3Request(AbstractRequest):
 
 class ClearSuspectBlobDs3TargetsSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(ClearSuspectBlobDs3TargetsSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'ClearSuspectBlobDs3TargetsSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_ds3_target'
@@ -3481,8 +3511,15 @@ class ClearSuspectBlobDs3TargetsSpectraS3Request(AbstractRequest):
 
 class ClearSuspectBlobPoolsSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(ClearSuspectBlobPoolsSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'ClearSuspectBlobPoolsSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_pool'
@@ -3491,8 +3528,15 @@ class ClearSuspectBlobPoolsSpectraS3Request(AbstractRequest):
 
 class ClearSuspectBlobS3TargetsSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(ClearSuspectBlobS3TargetsSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'ClearSuspectBlobS3TargetsSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_s3_target'
@@ -3501,8 +3545,15 @@ class ClearSuspectBlobS3TargetsSpectraS3Request(AbstractRequest):
 
 class ClearSuspectBlobTapesSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(ClearSuspectBlobTapesSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'ClearSuspectBlobTapesSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_tape'
@@ -3808,8 +3859,15 @@ class GetSuspectObjectsWithFullDetailsSpectraS3Request(AbstractRequest):
 
 class MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_azure_target'
@@ -3818,8 +3876,15 @@ class MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(AbstractRequest):
 
 class MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_ds3_target'
@@ -3828,8 +3893,15 @@ class MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(AbstractRequest):
 
 class MarkSuspectBlobPoolsAsDegradedSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(MarkSuspectBlobPoolsAsDegradedSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'MarkSuspectBlobPoolsAsDegradedSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_pool'
@@ -3838,8 +3910,15 @@ class MarkSuspectBlobPoolsAsDegradedSpectraS3Request(AbstractRequest):
 
 class MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_s3_target'
@@ -3848,8 +3927,15 @@ class MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(AbstractRequest):
 
 class MarkSuspectBlobTapesAsDegradedSpectraS3Request(AbstractRequest):
     
-    def __init__(self, force=None):
+    def __init__(self, id_list, force=None):
         super(MarkSuspectBlobTapesAsDegradedSpectraS3Request, self).__init__()
+        if id_list is not None:
+            if not (isinstance(cur_id, str) for cur_id in id_list):
+                raise TypeError(
+                    'MarkSuspectBlobTapesAsDegradedSpectraS3Request should have request payload of type: list of strings')
+            xml_id_list = IdsList(id_list)
+            self.body = xmldom.tostring(xml_id_list.to_xml())
+
         if force is not None:
             self.query_params['force'] = force
         self.path = '/_rest_/suspect_blob_tape'

--- a/tests/clientTests.py
+++ b/tests/clientTests.py
@@ -1384,6 +1384,14 @@ class MockedHttpResponse:
 
 
 class ResponseParsingTestCase(unittest.TestCase):
+    @staticmethod
+    def __get_test_ids():
+        return ['obj1', 'obj2', 'obj3']
+
+    @staticmethod
+    def __get_marshaled_ids():
+        return b'<Ids><Id>obj1</Id><Id>obj2</Id><Id>obj3</Id></Ids>'
+
     def testGetJobToReplicate(self):
         content = "some content to test response parsing"
 
@@ -1411,3 +1419,43 @@ class ResponseParsingTestCase(unittest.TestCase):
 
         request = VerifyPhysicalPlacementForObjectsSpectraS3Request(bucket_name="bucketName", object_list=l)
         self.assertEqual(request.body.decode(), '<Objects><Object Name="obj1" /><Object Name="obj2" /></Objects>')
+
+    def testClearSuspectBlobAzureTargetsRequestPayload(self):
+        request = ClearSuspectBlobAzureTargetsSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testClearSuspectBlobDs3TargetsRequestPayload(self):
+        request = ClearSuspectBlobDs3TargetsSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testClearSuspectBlobPoolsRequestPayload(self):
+        request = ClearSuspectBlobPoolsSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testClearSuspectBlobS3TargetsRequestPayload(self):
+        request = ClearSuspectBlobS3TargetsSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testClearSuspectBlobTapesRequestPayload(self):
+        request = ClearSuspectBlobTapesSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testMarkSuspectBlobAzureTargetsAsDegradedRequestPayload(self):
+        request = MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testMarkSuspectBlobPoolsAsDegradedRequestPayload(self):
+        request = MarkSuspectBlobPoolsAsDegradedSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testMarkSuspectBlobDs3TargetsAsDegradedRequestPayload(self):
+        request = MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testMarkSuspectBlobS3TargetsAsDegradedRequestPayload(self):
+        request = MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())
+
+    def testMarkSuspectBlobTapesAsDegradedRequestPayload(self):
+        request = MarkSuspectBlobTapesAsDegradedSpectraS3Request(id_list=self.__get_test_ids())
+        self.assertEqual(request.body, self.__get_marshaled_ids())


### PR DESCRIPTION
Added request payload of ids to all 5 clear blob and all 5 mark blob commands.
Added unit tests to verify correct request payload marshaling.