### PR TITLE
OTHER: When retrying a get available job chunks call in helpers and samples, we were incorrectly referencing a variable that no longer exists

### DIFF
--- a/ds3/ds3Helpers.py
+++ b/ds3/ds3Helpers.py
@@ -88,8 +88,9 @@ def object_name_to_file_path(object_name: str) -> str:
 
 
 class Helper(object):
-    def __init__(self, client: Client):
+    def __init__(self, client: Client, retry_delay_in_seconds: int = 60):
         self.client = client
+        self.retry_delay_in_seconds = retry_delay_in_seconds
 
     def put_objects(self, put_objects: List[HelperPutObject], bucket: str, max_threads: int = 5) -> str:
         ds3_put_objects: List[Ds3PutObject] = []
@@ -120,7 +121,7 @@ class Helper(object):
             chunks = available_chunks.result['ObjectsList']
 
             if len(chunks) <= 0:
-                time.sleep(available_chunks.retryAfter)
+                time.sleep(self.retry_delay_in_seconds)
                 continue
 
             # retrieve all available blobs concurrently
@@ -207,7 +208,7 @@ class Helper(object):
             chunks = available_chunks.result['ObjectsList']
 
             if len(chunks) <= 0:
-                time.sleep(available_chunks.retryAfter)
+                time.sleep(self.retry_delay_in_seconds)
                 continue
 
             # retrieve all available blobs concurrently

--- a/samples/gettingData.py
+++ b/samples/gettingData.py
@@ -67,7 +67,7 @@ while len(chunkIds) > 0:
     # Check to make sure we got some chunks, if we did not sleep and retry.
     # Having no chunks ready may indicate that the BP cache is currently full.
     if len(chunks) == 0:
-        time.sleep(availableChunks.retryAfter)
+        time.sleep(60)
         continue
 
     # For each chunk that is available, check to make sure we haven't processed it already.

--- a/samples/puttingData.py
+++ b/samples/puttingData.py
@@ -61,7 +61,7 @@ while len(chunkIds) > 0:
     # check to make sure we got some chunks, if we did not
     # sleep and retry.  This could mean that the cache is full
     if len(chunks) == 0:
-        time.sleep(availableChunks.retryAfter)
+        time.sleep(60)
         continue
 
     # for each chunk that is available, check to make sure

--- a/samples/puttingDataWithCRC32.py
+++ b/samples/puttingDataWithCRC32.py
@@ -63,7 +63,7 @@ while len(chunkIds) > 0:
     # check to make sure we got some chunks, if we did not
     # sleep and retry.  This could mean that the cache is full
     if len(chunks) == 0:
-        time.sleep(availableChunks.retryAfter)
+        time.sleep(60)
         continue
 
     # for each chunk that is available, check to make sure

--- a/samples/renaming.py
+++ b/samples/renaming.py
@@ -67,7 +67,7 @@ while len(chunkIds) > 0:
     # check to make sure we got some chunks, if we did not
     # sleep and retry.  This could mean that the cache is full
     if len(chunks) == 0:
-        time.sleep(availableChunks.retryAfter)
+        time.sleep(60)
         continue
 
     # for each chunk that is available, check to make sure


### PR DESCRIPTION
- Added variable to helper constructor which allows users to specify the number of seconds to wait between retrying the get job chunks availble call. Default is to wait 60 seconds. 
- Also updated the samples to specify a number.