### PR TITLE
Force CRC32 byte length to four

### DIFF
--- a/samples/puttingDataWithCRC32.py
+++ b/samples/puttingDataWithCRC32.py
@@ -18,6 +18,8 @@ import zlib
 
 client = ds3.createClientFromEnv()
 
+crc_byte_length = 4
+
 bucketName = "books"
 
 # make sure the bucket that we will be sending objects to exists
@@ -83,7 +85,8 @@ while len(chunkIds) > 0:
                 objectDataStream.seek(int(obj['Offset']), 0)
                 objectChunk = objectDataStream.read(int(obj['Length']))
                 checksum = zlib.crc32(objectChunk)
-                encodedChecksum = base64.b64encode(checksum.to_bytes((checksum.bit_length() + 7) // 8, byteorder='big')).decode()
+                encodedChecksum = base64.b64encode(
+                    checksum.to_bytes(crc_byte_length, byteorder='big')).decode()
                 objectDataStream.seek(int(obj['Offset']), 0)
                 client.put_object(ds3.PutObjectRequest(bucketName,
                                                        obj['Name'],


### PR DESCRIPTION
RMS-6746 shows a customer failing to PUT a large video object (now two files fail) with the python sdk because of a CRC mismatch. The checksum is correctly calculated but the encoding does not match because BP assumes a byte length of 4.

Replace the computation with set length of four.
