### PR TITLE
Issue 59: gettingData example was overwriting parts of objects when retrieving multi-blob objects from BP

### DIFF
--- a/samples/gettingData.py
+++ b/samples/gettingData.py
@@ -80,8 +80,9 @@ while len(chunkIds) > 0:
         # For each blob within this chunk, retrieve the data and land it on the destination.
         for obj in chunk['ObjectList']:
             # Open the destination file and seek to the offset corresponding with this blob.
-            objectStream = open(objectNameToDestinationPathMap[obj['Name']], "wb")
-            objectStream.seek(int(obj['Offset']))
+            fd = os.open(objectNameToDestinationPathMap[obj['Name']], os.O_CREAT | os.O_WRONLY)
+            objectStream = os.fdopen(fd, 'wb')
+            objectStream.seek(int(obj['Offset']), 0)
 
             # Get the blob for the current object and write it to the destination.
             client.get_object(ds3.GetObjectRequest(bucketName,

--- a/samples/puttingData.py
+++ b/samples/puttingData.py
@@ -69,10 +69,10 @@ while len(chunkIds) > 0:
     for chunk in chunks:
         if not chunk['ChunkId'] in chunkIds:
             continue
-        
+
         chunkIds.remove(chunk['ChunkId'])
         for obj in chunk['ObjectList']:
-            # it is possible that if we start resending a chunk, due to the program crashing, that 
+            # it is possible that if we start resending a chunk, due to the program crashing, that
             # some objects will already be in cache.  Check to make sure that they are not, and then
             # send the object to Spectra S3
             if obj['InCache'] == 'false':


### PR DESCRIPTION
Updating how the file is opened so that zero padding stops overwriting existing data on seek.